### PR TITLE
Use HMAC-SHA256 instead of SHA256 for hashing phone numbers

### DIFF
--- a/src/main/java/foundation/privacybydesign/sms/SMSConfiguration.java
+++ b/src/main/java/foundation/privacybydesign/sms/SMSConfiguration.java
@@ -1,13 +1,14 @@
 package foundation.privacybydesign.sms;
 
 import foundation.privacybydesign.sms.common.BaseConfiguration;
-import foundation.privacybydesign.sms.common.Sha256Hasher;
+import foundation.privacybydesign.sms.common.Hmac;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.irmacard.api.common.util.GsonUtil;
 
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Map;
+import java.security.InvalidKeyException;
 import java.security.KeyManagementException;
 import java.security.PrivateKey;
 
@@ -49,7 +50,7 @@ public class SMSConfiguration extends BaseConfiguration<SMSConfiguration> {
     // Can be generated for example as follows: `openssl rand 32 | base64`
     private String hmac_key_base64 = "";
 
-    private Sha256Hasher hmac;
+    private Hmac hmac;
 
     public static SMSConfiguration getInstance() {
         if (instance == null) {
@@ -67,7 +68,7 @@ public class SMSConfiguration extends BaseConfiguration<SMSConfiguration> {
         }
 
         byte[] hmac_key = Base64.getDecoder().decode(instance.hmac_key_base64);
-        instance.hmac = new Sha256Hasher(hmac_key);
+        instance.hmac = new Hmac(hmac_key);
     }
 
     public String getSMSSenderBackend() {
@@ -158,7 +159,7 @@ public class SMSConfiguration extends BaseConfiguration<SMSConfiguration> {
         return BaseConfiguration.getPrivateKey(private_key_path);
     }
 
-    public Sha256Hasher getHmac() {
+    public Hmac getHmac() {
         return hmac;
     }
 }

--- a/src/main/java/foundation/privacybydesign/sms/SMSConfiguration.java
+++ b/src/main/java/foundation/privacybydesign/sms/SMSConfiguration.java
@@ -1,10 +1,12 @@
 package foundation.privacybydesign.sms;
 
 import foundation.privacybydesign.sms.common.BaseConfiguration;
+import foundation.privacybydesign.sms.common.Sha256Hasher;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.irmacard.api.common.util.GsonUtil;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Map;
 import java.security.KeyManagementException;
 import java.security.PrivateKey;
@@ -42,6 +44,13 @@ public class SMSConfiguration extends BaseConfiguration<SMSConfiguration> {
     private String sms_attribute = "";
     private CMGatewayConfiguration cm = null;
 
+    // HMAC key with which phone numbers and IP addresses are HMACed when putting them into Redis.
+    // Must be base64-encoded random data of 32 bytes.
+    // Can be generated for example as follows: `openssl rand 32 | base64`
+    private String hmac_key_base64 = "";
+
+    private Sha256Hasher hmac;
+
     public static SMSConfiguration getInstance() {
         if (instance == null) {
             load();
@@ -56,6 +65,9 @@ public class SMSConfiguration extends BaseConfiguration<SMSConfiguration> {
         } catch (IOException e) {
             instance = new SMSConfiguration();
         }
+
+        byte[] hmac_key = Base64.getDecoder().decode(instance.hmac_key_base64);
+        instance.hmac = new Sha256Hasher(hmac_key);
     }
 
     public String getSMSSenderBackend() {
@@ -144,5 +156,9 @@ public class SMSConfiguration extends BaseConfiguration<SMSConfiguration> {
 
     public PrivateKey getPrivateKey() throws KeyManagementException {
         return BaseConfiguration.getPrivateKey(private_key_path);
+    }
+
+    public Sha256Hasher getHmac() {
+        return hmac;
     }
 }

--- a/src/main/java/foundation/privacybydesign/sms/common/Hmac.java
+++ b/src/main/java/foundation/privacybydesign/sms/common/Hmac.java
@@ -7,17 +7,20 @@ import java.util.Base64;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
-public class Sha256Hasher {
+public class Hmac {
   private final SecretKeySpec secretKey;
 
-  public Sha256Hasher(byte[] key) {
+  public Hmac(byte[] key)  {
+      if (key.length < 32) {
+          throw new RuntimeException("key too short: must be at least 32 bytes");
+      }
       this.secretKey = new SecretKeySpec(key, "HmacSHA256");
   }
 
-  public String CreateHash(String input) throws NoSuchAlgorithmException, InvalidKeyException {
+  public String createHmac(String input) throws NoSuchAlgorithmException, InvalidKeyException {
       final Mac hmac = Mac.getInstance("HmacSHA256");
       hmac.init(secretKey); // Initialize with the secret key
-      final byte[] encodedHash = hmac.doFinal(input.getBytes(StandardCharsets.UTF_8));
-      return Base64.getEncoder().encodeToString(encodedHash);
+      final byte[] encodedHmac = hmac.doFinal(input.getBytes(StandardCharsets.UTF_8));
+      return Base64.getEncoder().encodeToString(encodedHmac);
   }
 }

--- a/src/main/java/foundation/privacybydesign/sms/common/Sha256Hasher.java
+++ b/src/main/java/foundation/privacybydesign/sms/common/Sha256Hasher.java
@@ -1,14 +1,23 @@
 package foundation.privacybydesign.sms.common;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
-public final class Sha256Hasher {
-  public static String CreateHash(String input) throws NoSuchAlgorithmException {
-        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        final byte[] encodedhash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
-        return Base64.getEncoder().encodeToString(encodedhash);
-    }
+public class Sha256Hasher {
+  private final SecretKeySpec secretKey;
+
+  public Sha256Hasher(byte[] key) {
+      this.secretKey = new SecretKeySpec(key, "HmacSHA256");
+  }
+
+  public String CreateHash(String input) throws NoSuchAlgorithmException, InvalidKeyException {
+      final Mac hmac = Mac.getInstance("HmacSHA256");
+      hmac.init(secretKey); // Initialize with the secret key
+      final byte[] encodedHash = hmac.doFinal(input.getBytes(StandardCharsets.UTF_8));
+      return Base64.getEncoder().encodeToString(encodedHash);
+  }
 }

--- a/src/main/java/foundation/privacybydesign/sms/ratelimit/RateLimit.java
+++ b/src/main/java/foundation/privacybydesign/sms/ratelimit/RateLimit.java
@@ -3,7 +3,7 @@ package foundation.privacybydesign.sms.ratelimit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import foundation.privacybydesign.sms.common.Sha256Hasher;
+import foundation.privacybydesign.sms.common.Hmac;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -26,14 +26,14 @@ public abstract class RateLimit {
      *         it shouldn't wait.
      * @throws NoSuchAlgorithmException If the hashing algorithm in use isn't available on the system, this exception is thrown.
      */
-    public long rateLimited(String remoteAddr, String phone, Sha256Hasher hmac)
+    public long rateLimited(String remoteAddr, String phone, Hmac hmac)
             throws InvalidPhoneNumberException, NoSuchAlgorithmException, InvalidKeyException {
         long now = System.currentTimeMillis();
         
         String addr = getAddressPrefix(remoteAddr);
 
-        final String ipHash = hmac.CreateHash(addr);
-        final String phoneHash = hmac.CreateHash(phone);
+        final String ipHash = hmac.createHmac(addr);
+        final String phoneHash = hmac.createHmac(phone);
 
         long ipRetryAfter = nextTryIP(ipHash, now);
         long phoneRetryAfter = nextTryPhone(phoneHash, now);

--- a/src/main/java/foundation/privacybydesign/sms/ratelimit/RateLimit.java
+++ b/src/main/java/foundation/privacybydesign/sms/ratelimit/RateLimit.java
@@ -7,6 +7,7 @@ import foundation.privacybydesign.sms.common.Sha256Hasher;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 /**
@@ -25,14 +26,14 @@ public abstract class RateLimit {
      *         it shouldn't wait.
      * @throws NoSuchAlgorithmException If the hashing algorithm in use isn't available on the system, this exception is thrown.
      */
-    public long rateLimited(String remoteAddr, String phone)
-            throws InvalidPhoneNumberException, NoSuchAlgorithmException {
+    public long rateLimited(String remoteAddr, String phone, Sha256Hasher hmac)
+            throws InvalidPhoneNumberException, NoSuchAlgorithmException, InvalidKeyException {
         long now = System.currentTimeMillis();
         
         String addr = getAddressPrefix(remoteAddr);
 
-        final String ipHash = Sha256Hasher.CreateHash(addr);
-        final String phoneHash = Sha256Hasher.CreateHash(phone);
+        final String ipHash = hmac.CreateHash(addr);
+        final String phoneHash = hmac.CreateHash(phone);
 
         long ipRetryAfter = nextTryIP(ipHash, now);
         long phoneRetryAfter = nextTryPhone(phoneHash, now);

--- a/src/main/java/foundation/privacybydesign/sms/tokens/TokenManager.java
+++ b/src/main/java/foundation/privacybydesign/sms/tokens/TokenManager.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import foundation.privacybydesign.sms.common.Sha256Hasher;
 
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
@@ -39,8 +40,8 @@ public class TokenManager {
         return instance;
     }
 
-    public String generate(String phone) throws Exception {
-        final String phoneHash = Sha256Hasher.CreateHash(phone);
+    public String generate(String phone, Sha256Hasher hmac) throws Exception {
+        final String phoneHash = hmac.CreateHash(phone);
         
         // https://stackoverflow.com/a/41156/559350
         // There are 30 bits. Using 32 possible values per char means
@@ -61,8 +62,9 @@ public class TokenManager {
         return token;
     }
 
-    public boolean verify(String phone, String token) throws NoSuchAlgorithmException {
-        final String phoneHash = Sha256Hasher.CreateHash(phone);
+    public boolean verify(String phone, String token, Sha256Hasher hmac)
+            throws NoSuchAlgorithmException, InvalidKeyException {
+        final String phoneHash = hmac.CreateHash(phone);
         TokenRequest tr = tokenRepo.retrieve(phoneHash);
         if (tr == null) {
             LOG.error("Phone number not found");

--- a/src/main/java/foundation/privacybydesign/sms/tokens/TokenManager.java
+++ b/src/main/java/foundation/privacybydesign/sms/tokens/TokenManager.java
@@ -3,7 +3,7 @@ package foundation.privacybydesign.sms.tokens;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import foundation.privacybydesign.sms.common.Sha256Hasher;
+import foundation.privacybydesign.sms.common.Hmac;
 
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
@@ -40,8 +40,8 @@ public class TokenManager {
         return instance;
     }
 
-    public String generate(String phone, Sha256Hasher hmac) throws Exception {
-        final String phoneHash = hmac.CreateHash(phone);
+    public String generate(String phone, Hmac hmac) throws Exception {
+        final String phoneHash = hmac.createHmac(phone);
         
         // https://stackoverflow.com/a/41156/559350
         // There are 30 bits. Using 32 possible values per char means
@@ -62,9 +62,9 @@ public class TokenManager {
         return token;
     }
 
-    public boolean verify(String phone, String token, Sha256Hasher hmac)
+    public boolean verify(String phone, String token, Hmac hmac)
             throws NoSuchAlgorithmException, InvalidKeyException {
-        final String phoneHash = hmac.CreateHash(phone);
+        final String phoneHash = hmac.createHmac(phone);
         TokenRequest tr = tokenRepo.retrieve(phoneHash);
         if (tr == null) {
             LOG.error("Phone number not found");

--- a/src/main/resources/config.sample.json
+++ b/src/main/resources/config.sample.json
@@ -21,5 +21,6 @@
   "scheme_manager": "irma-demo",
   "sms_issuer": "sidn-pbdf",
   "sms_credential": "mobilenumber",
-  "sms_attribute": "mobilenumber"
+  "sms_attribute": "mobilenumber",
+  "hmac_key_base64": "<<insert output from `openssl rand 32 | base64` here>>"
 }


### PR DESCRIPTION
This solves [this issue](https://github.com/privacybydesign/irma_sms_issuer/pull/39#discussion_r1919787351) identified by @confiks by using HMAC-SHA256 on phone numbers instead of SHA256, before storing them as Redis keys.

Note that this adds new configuration to the application so the deployment(s) will need to be updated.