### PR TITLE
fix back button

### DIFF
--- a/webapp/common.js
+++ b/webapp/common.js
@@ -64,13 +64,9 @@ function setWindow(window, back) {
 
     const backButton = $('#back-button');
     backButton.off();
-    if (back) {
+    if (window == 'confirm') {
         backButton
           .click(() => {clearStatus(); setWindow(back); return false;})
-          .removeClass('button-hidden');
-    } else if (history.length >  1) {
-        backButton
-          .click(() => {clearStatus(); history.back(); return false;})
           .removeClass('button-hidden');
     } else {
         backButton.addClass('button-hidden');


### PR DESCRIPTION
This pull request includes a change to the `setWindow` function in `webapp/common.js` to modify the behavior of the back button. 
Changes to back button behavior:

* [`webapp/common.js`](diffhunk://#diff-888e9d62bdc8763490147befa24e76747f05840e51c3d630810db0e4767e9928L67-L74): Modified the `setWindow` function to check if the window is 'confirm' and set the back button accordingly. The back button no longer relies on user's browser tab history and instead only shown when window id contains 'confirm'.