### PR TITLE
chore: Version release with edge only on master branch

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -11,6 +11,7 @@ on:
   schedule:
     # Run every monday on 9:00 in the morning (UTC).
     - cron: '0 9 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -37,6 +38,7 @@ jobs:
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=edge,enable=${{ steps.is-head-main.outcome == 'success' }}
+            type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,13 +1,16 @@
 name: Delivery
 
-on: 
+on:
+  pull_request:
+    types: [synchronize, opened, reopened]
   push:
-    branches: [ master ]
+    branches: [master]
   release:
     # Note: a current limitation is that when a release is edited after publication, then the Docker tags are not automatically updated.
-    types: [ published ]
-  # Make it possible to trigger the checks manually.
-  workflow_dispatch:
+    types: [published]
+  schedule:
+    # Run every monday on 9:00 in the morning (UTC).
+    - cron: '0 9 * * 1'
 
 permissions:
   contents: write
@@ -20,6 +23,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check whether this event is the HEAD of main
+        continue-on-error: true
+        id: is-head-main
+        run: git rev-parse HEAD | grep -x ${{ github.sha }}
+        shell: bash
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -27,17 +36,21 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
-            type=raw,value=edge
+            type=edge,enable=${{ steps.is-head-main.outcome == 'success' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}      
-      
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build container and push to GitHub Container Registry
         uses: docker/build-push-action@v5
+        if: ${{ github.event_name == 'release' || github.event_name == 'push' }}
         with:
           context: .
           push: true


### PR DESCRIPTION
I'm separating the pull requests for versioning and vulnerability scanning because it's too risky to do both at once.